### PR TITLE
[Kerberos] Add Kerberos Realm

### DIFF
--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandler.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/DefaultAuthenticationFailureHandler.java
@@ -10,25 +10,36 @@ import org.elasticsearch.common.util.concurrent.ThreadContext;
 import org.elasticsearch.rest.RestRequest;
 import org.elasticsearch.rest.RestStatus;
 import org.elasticsearch.transport.TransportMessage;
+import org.elasticsearch.xpack.core.XPackField;
 
 import static org.elasticsearch.xpack.core.security.support.Exceptions.authenticationError;
 
 /**
- * The default implementation of a {@link AuthenticationFailureHandler}. This handler will return an exception with a
- * RestStatus of 401 and the WWW-Authenticate header with a Basic challenge.
+ * The default implementation of a {@link AuthenticationFailureHandler}. This
+ * handler will return an exception with a RestStatus of 401 and the
+ * WWW-Authenticate header with configured auth scheme else by default adds Basic challenge.
  */
 public class DefaultAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    private final String defaultWWWAuthenticateResponseHeader;
+
+    public DefaultAuthenticationFailureHandler() {
+        this("Basic realm=\"" + XPackField.SECURITY + "\" charset=\"UTF-8\"");
+    }
+
+    public DefaultAuthenticationFailureHandler(final String defaultWWWAuthenticateHeaderValue) {
+        defaultWWWAuthenticateResponseHeader = defaultWWWAuthenticateHeaderValue;
+    }
 
     @Override
-    public ElasticsearchSecurityException failedAuthentication(RestRequest request, AuthenticationToken token,
-                                                               ThreadContext context) {
-        return authenticationError("unable to authenticate user [{}] for REST request [{}]", token.principal(), request.uri());
+    public ElasticsearchSecurityException failedAuthentication(RestRequest request, AuthenticationToken token, ThreadContext context) {
+        return addHeader(
+                authenticationError("unable to authenticate user [{}] for REST request [{}]", token.principal(), request.uri()));
     }
 
     @Override
     public ElasticsearchSecurityException failedAuthentication(TransportMessage message, AuthenticationToken token, String action,
-                                                               ThreadContext context) {
-        return authenticationError("unable to authenticate user [{}] for action [{}]", token.principal(), action);
+            ThreadContext context) {
+        return addHeader(authenticationError("unable to authenticate user [{}] for action [{}]", token.principal(), action));
     }
 
     @Override
@@ -38,32 +49,44 @@ public class DefaultAuthenticationFailureHandler implements AuthenticationFailur
             assert ((ElasticsearchSecurityException) e).getHeader("WWW-Authenticate").size() == 1;
             return (ElasticsearchSecurityException) e;
         }
-        return authenticationError("error attempting to authenticate request", e);
+        return addHeader(authenticationError("error attempting to authenticate request", e));
     }
 
     @Override
     public ElasticsearchSecurityException exceptionProcessingRequest(TransportMessage message, String action, Exception e,
-                                                                     ThreadContext context) {
+            ThreadContext context) {
         if (e instanceof ElasticsearchSecurityException) {
             assert ((ElasticsearchSecurityException) e).status() == RestStatus.UNAUTHORIZED;
             assert ((ElasticsearchSecurityException) e).getHeader("WWW-Authenticate").size() == 1;
             return (ElasticsearchSecurityException) e;
         }
-        return authenticationError("error attempting to authenticate request", e);
+        return addHeader(authenticationError("error attempting to authenticate request", e));
     }
 
     @Override
     public ElasticsearchSecurityException missingToken(RestRequest request, ThreadContext context) {
-        return authenticationError("missing authentication token for REST request [{}]", request.uri());
+        return addHeader(authenticationError("missing authentication token for REST request [{}]", request.uri()));
     }
 
     @Override
     public ElasticsearchSecurityException missingToken(TransportMessage message, String action, ThreadContext context) {
-        return authenticationError("missing authentication token for action [{}]", action);
+        return addHeader(authenticationError("missing authentication token for action [{}]", action));
     }
 
     @Override
     public ElasticsearchSecurityException authenticationRequired(String action, ThreadContext context) {
-        return authenticationError("action [{}] requires authentication", action);
+        return addHeader(authenticationError("action [{}] requires authentication", action));
+    }
+
+    /**
+     * This method replaces existing 'WWW-Authenticate' header if any
+     *
+     * @param ese instance of {@link ElasticsearchSecurityException}
+     * @return same instance of {@link ElasticsearchSecurityException} with header
+     *         'WWW-Authenticate'
+     */
+    private ElasticsearchSecurityException addHeader(ElasticsearchSecurityException ese) {
+        ese.addHeader("WWW-Authenticate", defaultWWWAuthenticateResponseHeader);
+        return ese;
     }
 }

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/Realm.java
@@ -8,6 +8,7 @@ package org.elasticsearch.xpack.core.security.authc;
 import org.apache.logging.log4j.Logger;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.security.user.User;
 
 import java.util.HashMap;
@@ -54,6 +55,22 @@ public abstract class Realm implements Comparable<Realm> {
      */
     public int order() {
         return config.order;
+    }
+
+    /**
+     * Each Realm can define its own 'WWW-Authenticate' header
+     * <p>
+     * By default the auth scheme is 'Basic', realms like <br>
+     * Kerberos can use 'Negotiate' scheme or<br>
+     * OAuth could use 'Bearer' scheme or<br>
+     * custom realms with custom auth scheme as defined in
+     * <a href="https://tools.ietf.org/html/rfc7235#section-4.1">RFC7235</a><br>
+     * For SAML, unofficially 'SAML' has been used for auth scheme.
+     *
+     * @return default value to be returned in `WWW-Authenticate` response header.
+     */
+    public String getWWWAuthenticateHeaderValue() {
+        return "Basic realm=\"" + XPackField.SECURITY + "\" charset=\"UTF-8\"";
     }
 
     @Override

--- a/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UsernamePasswordToken.java
+++ b/x-pack/plugin/core/src/main/java/org/elasticsearch/xpack/core/security/authc/support/UsernamePasswordToken.java
@@ -5,16 +5,17 @@
  */
 package org.elasticsearch.xpack.core.security.authc.support;
 
+import org.elasticsearch.ElasticsearchSecurityException;
 import org.elasticsearch.common.settings.SecureString;
 import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.rest.RestStatus;
+import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
 
 import java.nio.CharBuffer;
 import java.util.Arrays;
 import java.util.Base64;
 import java.util.Objects;
-
-import static org.elasticsearch.xpack.core.security.support.Exceptions.authenticationError;
 
 public class UsernamePasswordToken implements AuthenticationToken {
 
@@ -94,19 +95,19 @@ public class UsernamePasswordToken implements AuthenticationToken {
 
         // if there is nothing after the prefix, the header is bad
         if (headerValue.length() == BASIC_AUTH_PREFIX.length()) {
-            throw authenticationError("invalid basic authentication header value");
+            throw unauthorized("invalid basic authentication header value", null);
         }
 
         char[] userpasswd;
         try {
             userpasswd = CharArrays.utf8BytesToChars(Base64.getDecoder().decode(headerValue.substring(BASIC_AUTH_PREFIX.length()).trim()));
         } catch (IllegalArgumentException e) {
-            throw authenticationError("invalid basic authentication header encoding", e);
+            throw unauthorized("invalid basic authentication header encoding", e);
         }
 
         int i = CharArrays.indexOf(userpasswd, ':');
         if (i < 0) {
-            throw authenticationError("invalid basic authentication header value");
+            throw unauthorized("invalid basic authentication header value", null);
         }
 
         return new UsernamePasswordToken(
@@ -118,4 +119,9 @@ public class UsernamePasswordToken implements AuthenticationToken {
         context.putHeader(BASIC_AUTH_HEADER, basicAuthHeaderValue(token.username, token.password));
     }
 
+    static ElasticsearchSecurityException unauthorized(final String message, final Throwable cause, final Object... args) {
+        ElasticsearchSecurityException ese = new ElasticsearchSecurityException(message, RestStatus.UNAUTHORIZED, cause, args);
+        ese.addHeader("WWW-Authenticate", "Basic realm=\"" + XPackField.SECURITY + "\" charset=\"UTF-8\"");
+        return ese;
+    }
 }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheck.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheck.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.xpack.core.security.authc.RealmSettings;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Performs bootstrap checks required across security realms.
+ */
+public class RealmConfigBootstrapCheck implements BootstrapCheck {
+
+    @Override
+    public BootstrapCheckResult check(BootstrapContext context) {
+        BootstrapCheckResult result = BootstrapCheckResult.success();
+        try {
+            final Settings realmsSettings = RealmSettings.get(context.settings);
+            final Set<String> registeredRealmTypes = new HashSet<>();
+            final Set<String> internalTypes = new HashSet<>();
+            for (String name : realmsSettings.names()) {
+                final Settings realmSettings = realmsSettings.getAsSettings(name);
+                final String type = realmSettings.get("type");
+                if (Strings.isNullOrEmpty(type)) {
+                    throw new IllegalArgumentException("missing realm type for [" + name + "] realm");
+                }
+                if (FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type)) {
+                    // this is an internal realm factory, let's make sure we didn't already
+                    // registered one (there can only be one instance of an internal realm)
+                    if (internalTypes.contains(type)) {
+                        throw new IllegalArgumentException("multiple [" + type + "] realms are configured. [" + type
+                                + "] is an internal realm and therefore there can only be one such realm configured");
+                    }
+                    internalTypes.add(type);
+                }
+                if (KerberosRealmSettings.TYPE.equals(type) && registeredRealmTypes.contains(type)) {
+                    // Kerberos realm can have only one instance.
+                    throw new IllegalArgumentException("multiple [" + type + "] realms are configured. For [" + type
+                            + "] there can only be one such realm configured");
+                }
+                registeredRealmTypes.add(type);
+            }
+        } catch (Exception e) {
+            result = BootstrapCheckResult.failure(e.getMessage());
+        }
+        return result;
+    }
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/Security.java
@@ -79,6 +79,7 @@ import org.elasticsearch.transport.TransportInterceptor;
 import org.elasticsearch.transport.TransportRequest;
 import org.elasticsearch.transport.TransportRequestHandler;
 import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.XPackField;
 import org.elasticsearch.xpack.core.XPackPlugin;
 import org.elasticsearch.xpack.core.XPackSettings;
 import org.elasticsearch.xpack.core.security.SecurityContext;
@@ -442,7 +443,18 @@ public class Security extends Plugin implements ActionPlugin, IngestPlugin, Netw
         }
         if (failureHandler == null) {
             logger.debug("Using default authentication failure handler");
-            failureHandler = new DefaultAuthenticationFailureHandler();
+            String defaultAuthenticateHeaderValue = "Basic realm=\"" + XPackField.SECURITY + "\" charset=\"UTF-8\"";
+            if (realms != null) {
+                final List<Realm> orderedListOfRealms = realms.asList();
+                if (orderedListOfRealms.isEmpty() == false) {
+                    // Last realm from ordered list determines the value for header
+                    // `WWW-Authenticate:` if not populated in the ElasticsearchSecurityException
+                    // headers.
+                    defaultAuthenticateHeaderValue =
+                            orderedListOfRealms.get(orderedListOfRealms.size() - 1).getWWWAuthenticateHeaderValue();
+                }
+            }
+            failureHandler = new DefaultAuthenticationFailureHandler(defaultAuthenticateHeaderValue);
         } else {
             logger.debug("Using authentication failure handler from extension [" + extensionName + "]");
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/AuthenticationService.java
@@ -266,13 +266,13 @@ public class AuthenticationService extends AbstractComponent {
                                 authenticatedBy = new RealmRef(realm.name(), realm.type(), nodeName);
                                 userListener.onResponse(result.getUser());
                             } else {
-                                // the user was not authenticated, call this so we can audit the correct event
-                                request.realmAuthenticationFailed(authenticationToken, realm.name());
                                 if (result.getStatus() == AuthenticationResult.Status.TERMINATE) {
-                                    logger.info("Authentication of [{}] was terminated by realm [{}] - {}",
-                                            authenticationToken.principal(), realm.name(), result.getMessage());
-                                    userListener.onFailure(Exceptions.authenticationError(result.getMessage(), result.getException()));
+                                    logger.info("Authentication of [{}] was terminated by realm [{}] - {}", authenticationToken.principal(),
+                                            realm.name(), result.getMessage());
+                                    listener.onFailure(request.exceptionProcessingRequest(result.getException(), authenticationToken));
                                 } else {
+                                    // the user was not authenticated, call this so we can audit the correct event
+                                    request.realmAuthenticationFailed(authenticationToken, realm.name());
                                     if (result.getMessage() != null) {
                                         messages.put(realm, new Tuple<>(result.getMessage(), result.getException()));
                                     }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/InternalRealms.java
@@ -16,6 +16,7 @@ import org.elasticsearch.xpack.core.security.authc.RealmConfig;
 import org.elasticsearch.xpack.core.security.authc.RealmSettings;
 import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.ldap.LdapRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
 import org.elasticsearch.xpack.core.security.authc.saml.SamlRealmSettings;
@@ -24,6 +25,7 @@ import org.elasticsearch.xpack.security.authc.esnative.NativeRealm;
 import org.elasticsearch.xpack.security.authc.esnative.NativeUsersStore;
 import org.elasticsearch.xpack.security.authc.esnative.ReservedRealm;
 import org.elasticsearch.xpack.security.authc.file.FileRealm;
+import org.elasticsearch.xpack.security.authc.kerberos.KerberosRealm;
 import org.elasticsearch.xpack.security.authc.ldap.LdapRealm;
 import org.elasticsearch.xpack.security.authc.pki.PkiRealm;
 import org.elasticsearch.xpack.security.authc.saml.SamlRealm;
@@ -52,7 +54,7 @@ public final class InternalRealms {
      */
     private static final Set<String> XPACK_TYPES = Collections.unmodifiableSet(new HashSet<>(Arrays.asList(
             NativeRealmSettings.TYPE, FileRealmSettings.TYPE, LdapRealmSettings.AD_TYPE, LdapRealmSettings.LDAP_TYPE, PkiRealmSettings.TYPE,
-            SamlRealmSettings.TYPE
+            SamlRealmSettings.TYPE, KerberosRealmSettings.TYPE
     )));
 
     /**
@@ -105,6 +107,7 @@ public final class InternalRealms {
                 sslService, resourceWatcherService, nativeRoleMappingStore, threadPool));
         map.put(PkiRealmSettings.TYPE, config -> new PkiRealm(config, resourceWatcherService, nativeRoleMappingStore));
         map.put(SamlRealmSettings.TYPE, config -> SamlRealm.create(config, sslService, resourceWatcherService, nativeRoleMappingStore));
+        map.put(KerberosRealmSettings.TYPE, config -> new KerberosRealm(config, nativeRoleMappingStore, threadPool));
         return Collections.unmodifiableMap(map);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/Realms.java
@@ -146,14 +146,10 @@ public class Realms extends AbstractComponent implements Iterable<Realm> {
 
     protected List<Realm> initRealms() throws Exception {
         Settings realmsSettings = RealmSettings.get(settings);
-        Set<String> internalTypes = new HashSet<>();
         List<Realm> realms = new ArrayList<>();
         for (String name : realmsSettings.names()) {
             Settings realmSettings = realmsSettings.getAsSettings(name);
             String type = realmSettings.get("type");
-            if (type == null) {
-                throw new IllegalArgumentException("missing realm type for [" + name + "] realm");
-            }
             Realm.Factory factory = factories.get(type);
             if (factory == null) {
                 throw new IllegalArgumentException("unknown realm type [" + type + "] set for realm [" + name + "]");
@@ -164,15 +160,6 @@ public class Realms extends AbstractComponent implements Iterable<Realm> {
                     logger.debug("realm [{}/{}] is disabled", type, name);
                 }
                 continue;
-            }
-            if (FileRealmSettings.TYPE.equals(type) || NativeRealmSettings.TYPE.equals(type)) {
-                // this is an internal realm factory, let's make sure we didn't already registered one
-                // (there can only be one instance of an internal realm)
-                if (internalTypes.contains(type)) {
-                    throw new IllegalArgumentException("multiple [" + type + "] realms are configured. [" + type +
-                            "] is an internal realm and therefore there can only be one such realm configured");
-                }
-                internalTypes.add(type);
             }
             realms.add(factory.create(config));
         }

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationToken.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationToken.java
@@ -50,11 +50,12 @@ public final class KerberosAuthenticationToken implements AuthenticationToken {
         }
 
         boolean ignoreCase = true;
-        if (authHeader.regionMatches(ignoreCase, 0, NEGOTIATE_AUTH_HEADER, 0, NEGOTIATE_AUTH_HEADER.length()) == Boolean.FALSE) {
+        if (authHeader.regionMatches(ignoreCase, 0, NEGOTIATE_AUTH_HEADER.trim(), 0,
+                NEGOTIATE_AUTH_HEADER.trim().length()) == Boolean.FALSE) {
             return null;
         }
 
-        final String base64EncodedToken = authHeader.substring(NEGOTIATE_AUTH_HEADER.length()).trim();
+        final String base64EncodedToken = authHeader.substring(NEGOTIATE_AUTH_HEADER.trim().length()).trim();
         if (Strings.isEmpty(base64EncodedToken)) {
             throw unauthorized("invalid negotiate authentication header value, expected base64 encoded token but value is empty", null);
         }
@@ -63,8 +64,7 @@ public final class KerberosAuthenticationToken implements AuthenticationToken {
         try {
             decodedKerberosTicket = Base64.getDecoder().decode(base64Token);
         } catch (IllegalArgumentException iae) {
-            throw unauthorized("invalid negotiate authentication header value, could not decode base64 token {}", iae,
-                    base64EncodedToken);
+            throw unauthorized("invalid negotiate authentication header value, could not decode base64 token {}", iae, base64EncodedToken);
         }
 
         return new KerberosAuthenticationToken(decodedKerberosTicket);
@@ -103,7 +103,7 @@ public final class KerberosAuthenticationToken implements AuthenticationToken {
         return Objects.equals(otherKerbToken.credentials(), credentials());
     }
 
-    private static ElasticsearchSecurityException unauthorized(final String message, final Throwable cause, final Object... args) {
+    static ElasticsearchSecurityException unauthorized(final String message, final Throwable cause, final Object... args) {
         ElasticsearchSecurityException ese = new ElasticsearchSecurityException(message, RestStatus.UNAUTHORIZED, cause, args);
         ese.addHeader(WWW_AUTHENTICATE, NEGOTIATE_AUTH_HEADER.trim());
         return ese;

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealm.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security.authc.kerberos;
+
+import org.apache.logging.log4j.Level;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.cache.CacheBuilder;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationToken;
+import org.elasticsearch.xpack.core.security.authc.Realm;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.kerberos.support.KerberosTicketValidator;
+import org.elasticsearch.xpack.security.authc.support.CachingRealm;
+import org.elasticsearch.xpack.security.authc.support.UserRoleMapper;
+import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+
+import java.util.Collections;
+
+import javax.security.auth.login.LoginException;
+
+/**
+ * Kerberos Realm - only SPNEGO mechanism is supported for authentication.
+ */
+public final class KerberosRealm extends Realm implements CachingRealm {
+
+    private final Cache<String, User> userPrincipalNameToUserCache;
+    private final NativeRoleMappingStore userRoleMapper;
+    private final KerberosTicketValidator kerberosTicketValidator;
+    private final ThreadPool threadPool;
+
+    public KerberosRealm(final RealmConfig config, final NativeRoleMappingStore nativeRoleMappingStore, final ThreadPool threadPool) {
+        this(config, nativeRoleMappingStore, new KerberosTicketValidator(), threadPool, null);
+    }
+
+    // pkg scoped for testing
+    KerberosRealm(final RealmConfig config, final NativeRoleMappingStore nativeRoleMappingStore,
+            final KerberosTicketValidator kerberosTicketValidator, final ThreadPool threadPool,
+            final Cache<String, User> userPrincipalNameToUserCache) {
+        super(KerberosRealmSettings.TYPE, config);
+        this.userRoleMapper = nativeRoleMappingStore;
+        this.userRoleMapper.refreshRealmOnChange(this);
+        this.userPrincipalNameToUserCache = (userPrincipalNameToUserCache == null)
+                ? CacheBuilder.<String, User>builder().setExpireAfterWrite(KerberosRealmSettings.CACHE_TTL_SETTING.get(config.settings()))
+                        .setMaximumWeight(KerberosRealmSettings.CACHE_MAX_USERS_SETTING.get(config.settings())).build()
+                : userPrincipalNameToUserCache;
+        this.kerberosTicketValidator = kerberosTicketValidator;
+        this.threadPool = threadPool;
+    }
+
+    @Override
+    public String getWWWAuthenticateHeaderValue() {
+        return KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER.trim();
+    }
+
+    @Override
+    public void expire(final String username) {
+        userPrincipalNameToUserCache.invalidate(username);
+    }
+
+    @Override
+    public void expireAll() {
+        userPrincipalNameToUserCache.invalidateAll();
+    }
+
+    @Override
+    public boolean supports(final AuthenticationToken token) {
+        return token instanceof KerberosAuthenticationToken;
+    }
+
+    @Override
+    public AuthenticationToken token(final ThreadContext context) {
+        return KerberosAuthenticationToken.extractToken(context);
+    }
+
+    @Override
+    public void authenticate(final AuthenticationToken token, final ActionListener<AuthenticationResult> listener) {
+        if (token instanceof KerberosAuthenticationToken) {
+            final KerberosAuthenticationToken kerbAuthnToken = (KerberosAuthenticationToken) token;
+            AuthenticationResult authenticationResult = AuthenticationResult.terminate("Spnego authentication failure", null);
+
+            try {
+                final Tuple<String, String> userPrincipalNameOutToken = kerberosTicketValidator.validateTicket("*",
+                        GSSName.NT_HOSTBASED_SERVICE, (byte[]) kerbAuthnToken.credentials(), config);
+
+                if (userPrincipalNameOutToken != null && userPrincipalNameOutToken.v1() != null) {
+                    userDetails(userPrincipalNameOutToken, listener);
+                    return;
+                } else {
+                    String errorMessage = "failed to authenticate user, invalid kerberos ticket";
+                    String outToken = "";
+                    if (userPrincipalNameOutToken != null) {
+                        // Ongoing sec context establishment, return UNAUTHORIZED with out token if any
+                        outToken = userPrincipalNameOutToken.v2();
+                        errorMessage = "failed to authenticate user, gss netogiation not complete";
+                    }
+                    addResponseHeaderToThreadContext(outToken);
+                    authenticationResult = AuthenticationResult.terminate(errorMessage, null);
+                }
+            } catch (LoginException e) {
+                logger.log(Level.ERROR, "Exception occurred in service login", e);
+                authenticationResult = AuthenticationResult.terminate("failed to authenticate user, service login failure",
+                        KerberosAuthenticationToken.unauthorized(e.getLocalizedMessage(), e, (Object[]) null));
+            } catch (GSSException e) {
+                logger.log(Level.ERROR, "Exception occurred in GSS-API", e);
+                authenticationResult = AuthenticationResult.terminate("failed to authenticate user, GSS negotiation failure",
+                        KerberosAuthenticationToken.unauthorized(e.getLocalizedMessage(), e, (Object[]) null));
+            }
+
+            listener.onResponse(authenticationResult);
+        } else {
+            listener.onResponse(AuthenticationResult.notHandled());
+        }
+    }
+
+    private void userDetails(final Tuple<String, String> userPrincipalNameOutToken, final ActionListener<AuthenticationResult> listener) {
+        // Add token if any to response header
+        addResponseHeaderToThreadContext(userPrincipalNameOutToken.v2());
+
+        final String username = userPrincipalNameOutToken.v1();
+        User user = userPrincipalNameToUserCache.get(username);
+        if (user != null) {
+            listener.onResponse(AuthenticationResult.success(user));
+        } else {
+            final UserRoleMapper.UserData userData = new UserRoleMapper.UserData(username, null, Collections.emptySet(), null, this.config);
+            userRoleMapper.resolveRoles(userData, ActionListener.wrap(roles -> {
+                final User computedUser = new User(username, roles.toArray(new String[roles.size()]), null, null, null, true);
+                userPrincipalNameToUserCache.put(username, computedUser);
+                listener.onResponse(AuthenticationResult.success(computedUser));
+            }, listener::onFailure));
+
+            /**
+             * TODO: bizybot AD/LDAP user lookup if lookup realm configured
+             */
+        }
+    }
+
+    private void addResponseHeaderToThreadContext(String outToken) {
+        threadPool.getThreadContext().addResponseHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE,
+                KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER + outToken);
+    }
+
+    @Override
+    public void lookupUser(String username, ActionListener<User> listener) {
+        // TODO bizybot support later
+        listener.onResponse(null);
+    }
+
+}

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/pki/PkiRealm.java
@@ -86,6 +86,7 @@ public class PkiRealm extends Realm implements CachingRealm {
         this.trustManager = trustManagers(config);
         this.principalPattern = PkiRealmSettings.USERNAME_PATTERN_SETTING.get(config.settings());
         this.roleMapper = roleMapper;
+        this.roleMapper.refreshRealmOnChange(this);
         this.cache = CacheBuilder.<BytesKey, User>builder()
                 .setExpireAfterWrite(PkiRealmSettings.CACHE_TTL_SETTING.get(config.settings()))
                 .setMaximumWeight(PkiRealmSettings.CACHE_MAX_USERS_SETTING.get(config.settings()))

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingRealm.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/CachingRealm.java
@@ -14,6 +14,10 @@ import org.elasticsearch.xpack.core.security.authc.Realm;
 public interface CachingRealm {
 
     /**
+     * @return The name of this realm.
+     */
+    String name();
+    /**
      * Expires a single user from the cache identified by the String agument
      * @param username the identifier of the user to be cleared
      */

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/DnRoleMapper.java
@@ -69,7 +69,7 @@ public class DnRoleMapper implements UserRoleMapper {
     }
 
     @Override
-    public void refreshRealmOnChange(CachingUsernamePasswordRealm realm) {
+    public void refreshRealmOnChange(CachingRealm realm) {
         addListener(realm::expireAll);
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/UserRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/UserRoleMapper.java
@@ -44,7 +44,7 @@ public interface UserRoleMapper {
      * the whole cluster depending on whether this role-mapper has node-local data or cluster-wide
      * data.
      */
-    void refreshRealmOnChange(CachingUsernamePasswordRealm realm);
+    void refreshRealmOnChange(CachingRealm realm);
 
     /**
      * A representation of a user for whom roles should be mapped.

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/CompositeRoleMapper.java
@@ -16,7 +16,7 @@ import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.support.GroupedActionListener;
 import org.elasticsearch.watcher.ResourceWatcherService;
 import org.elasticsearch.xpack.core.security.authc.RealmConfig;
-import org.elasticsearch.xpack.security.authc.support.CachingUsernamePasswordRealm;
+import org.elasticsearch.xpack.security.authc.support.CachingRealm;
 import org.elasticsearch.xpack.security.authc.support.DnRoleMapper;
 import org.elasticsearch.xpack.security.authc.support.UserRoleMapper;
 
@@ -48,7 +48,7 @@ public class CompositeRoleMapper implements UserRoleMapper {
     }
 
     @Override
-    public void refreshRealmOnChange(CachingUsernamePasswordRealm realm) {
+    public void refreshRealmOnChange(CachingRealm realm) {
         this.delegates.forEach(mapper -> mapper.refreshRealmOnChange(realm));
     }
 

--- a/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
+++ b/x-pack/plugin/security/src/main/java/org/elasticsearch/xpack/security/authc/support/mapper/NativeRoleMappingStore.java
@@ -34,7 +34,7 @@ import org.elasticsearch.xpack.core.security.action.rolemapping.PutRoleMappingRe
 import org.elasticsearch.xpack.core.security.authc.support.mapper.ExpressionRoleMapping;
 import org.elasticsearch.xpack.core.security.authc.support.mapper.expressiondsl.ExpressionModel;
 import org.elasticsearch.xpack.core.security.client.SecurityClient;
-import org.elasticsearch.xpack.security.authc.support.CachingUsernamePasswordRealm;
+import org.elasticsearch.xpack.security.authc.support.CachingRealm;
 import org.elasticsearch.xpack.security.authc.support.UserRoleMapper;
 import org.elasticsearch.xpack.security.support.SecurityIndexManager;
 
@@ -369,7 +369,7 @@ public class NativeRoleMappingStore extends AbstractComponent implements UserRol
      * @see ClearRealmCacheAction
      */
     @Override
-    public void refreshRealmOnChange(CachingUsernamePasswordRealm realm) {
+    public void refreshRealmOnChange(CachingRealm realm) {
         realmsToRefresh.add(realm.name());
     }
 }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheckTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/RealmConfigBootstrapCheckTests.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security;
+
+import org.elasticsearch.bootstrap.BootstrapCheck;
+import org.elasticsearch.bootstrap.BootstrapContext;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.xpack.core.security.authc.esnative.NativeRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.file.FileRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.kerberos.KerberosRealmSettings;
+import org.elasticsearch.xpack.core.security.authc.pki.PkiRealmSettings;
+import org.junit.Before;
+
+public class RealmConfigBootstrapCheckTests extends ESTestCase {
+    private Settings.Builder builder;
+
+    @Before
+    public void setup() {
+        builder = Settings.builder();
+        builder.put("path.home", createTempDir());
+    }
+
+    public void testRealmsNoErrors() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, randomInt(5), builder);
+        withRealm(KerberosRealmSettings.TYPE, 1, builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        assertTrue(runCheck(builder.build()).isSuccess());
+    }
+
+    public void testRealmsWithMultipleInternalRealmsConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(KerberosRealmSettings.TYPE, 1, builder);
+        withRealm(FileRealmSettings.TYPE, 2, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertTrue(result.isFailure());
+        assertEquals("multiple [" + FileRealmSettings.TYPE + "] realms are configured. [" + FileRealmSettings.TYPE
+                + "] is an internal realm and therefore there can only be one such realm configured", result.getMessage());
+    }
+
+    public void testRealmsWithMultipleKerberosRealmsConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(KerberosRealmSettings.TYPE, 2, builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertTrue(result.isFailure());
+        assertEquals("multiple [" + KerberosRealmSettings.TYPE + "] realms are configured. For [" + KerberosRealmSettings.TYPE
+                + "] there can only be one such realm configured", result.getMessage());
+    }
+
+    public void testRealmsWithEmptyTypeConfiguredFailingBootstrapCheck() throws Exception {
+        withRealm(PkiRealmSettings.TYPE, 2, builder);
+        withRealm(KerberosRealmSettings.TYPE, 1, builder);
+        withRealm(FileRealmSettings.TYPE, 1, builder);
+        withRealm(NativeRealmSettings.TYPE, 1, builder);
+        String name = randomAlphaOfLength(4) ;
+        builder.put("xpack.security.authc.realms."+name+".type", "");
+        BootstrapCheck.BootstrapCheckResult result = runCheck(builder.build());
+        assertTrue(result.isFailure());
+        assertEquals("missing realm type for [" + name + "] realm", result.getMessage());
+    }
+
+    private static void withRealm(String type, int instances, Settings.Builder builder) {
+        for (int i = 0 ; i < instances ; i++) {
+            builder.put("xpack.security.authc.realms."+randomAlphaOfLength(4) +".type", type);
+        }
+    }
+
+    private BootstrapCheck.BootstrapCheckResult runCheck(Settings settings) throws Exception {
+        return new RealmConfigBootstrapCheck().check(new BootstrapContext(settings, null));
+    }
+}

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationTokenTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosAuthenticationTokenTests.java
@@ -61,7 +61,9 @@ public class KerberosAuthenticationTokenTests extends ESTestCase {
     }
 
     public void testExtractTokenForInvalidAuthorizationHeaderThrowsException() throws IOException {
-        threadContext.putHeader(KerberosAuthenticationToken.AUTH_HEADER, KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER);
+        final String header =
+                randomFrom(KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER, "negotiate", "negotiate ", "Negotiate", "Negotiate        ");
+        threadContext.putHeader(KerberosAuthenticationToken.AUTH_HEADER, header);
 
         thrown.expect(ElasticsearchSecurityException.class);
         thrown.expectMessage(
@@ -85,12 +87,10 @@ public class KerberosAuthenticationTokenTests extends ESTestCase {
     }
 
     public void testExtractTokenForNoAuthorizationHeaderShouldReturnNull() throws IOException {
-        final KerberosAuthenticationToken kerbAuthnToken = KerberosAuthenticationToken.extractToken(threadContext);
-        assertNull(kerbAuthnToken);
-    }
-
-    public void testExtractTokenForBasicAuthorizationHeaderShouldReturnNull() throws IOException {
-        threadContext.putHeader(KerberosAuthenticationToken.AUTH_HEADER, "Basic ");
+        final String header = randomFrom(" Negotiate", "Basic ", " Random ", null);
+        if (header != null) {
+            threadContext.putHeader(KerberosAuthenticationToken.AUTH_HEADER, header);
+        }
         final KerberosAuthenticationToken kerbAuthnToken = KerberosAuthenticationToken.extractToken(threadContext);
         assertNull(kerbAuthnToken);
     }

--- a/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
+++ b/x-pack/plugin/security/src/test/java/org/elasticsearch/xpack/security/authc/kerberos/KerberosRealmTests.java
@@ -1,0 +1,406 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License;
+ * you may not use this file except in compliance with the Elastic License.
+ */
+
+package org.elasticsearch.xpack.security.authc.kerberos;
+
+import org.elasticsearch.ElasticsearchSecurityException;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.support.PlainActionFuture;
+import org.elasticsearch.client.Client;
+import org.elasticsearch.cluster.ClusterName;
+import org.elasticsearch.cluster.health.ClusterHealthStatus;
+import org.elasticsearch.common.Strings;
+import org.elasticsearch.common.cache.Cache;
+import org.elasticsearch.common.collect.Tuple;
+import org.elasticsearch.common.settings.SecureString;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.util.concurrent.ThreadContext;
+import org.elasticsearch.env.TestEnvironment;
+import org.elasticsearch.test.ESTestCase;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.elasticsearch.watcher.ResourceWatcherService;
+import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheAction;
+import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheRequest;
+import org.elasticsearch.xpack.core.security.action.realm.ClearRealmCacheResponse;
+import org.elasticsearch.xpack.core.security.authc.AuthenticationResult;
+import org.elasticsearch.xpack.core.security.authc.RealmConfig;
+import org.elasticsearch.xpack.core.security.authc.support.UsernamePasswordToken;
+import org.elasticsearch.xpack.core.security.support.Exceptions;
+import org.elasticsearch.xpack.core.security.user.User;
+import org.elasticsearch.xpack.security.authc.kerberos.support.KerberosTestCase;
+import org.elasticsearch.xpack.security.authc.kerberos.support.KerberosTicketValidator;
+import org.elasticsearch.xpack.security.authc.support.UserRoleMapper;
+import org.elasticsearch.xpack.security.authc.support.mapper.NativeRoleMappingStore;
+import org.elasticsearch.xpack.security.support.SecurityIndexManager;
+import org.hamcrest.BaseMatcher;
+import org.hamcrest.Description;
+import org.ietf.jgss.GSSException;
+import org.ietf.jgss.GSSName;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.rules.ExpectedException;
+import org.mockito.AdditionalMatchers;
+import org.mockito.Mockito;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import javax.security.auth.login.LoginException;
+
+import static org.hamcrest.Matchers.sameInstance;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.when;
+
+public class KerberosRealmTests extends ESTestCase {
+
+    private ThreadPool threadPool;
+    private Settings globalSettings;
+    private ResourceWatcherService resourceWatcherService;
+    private Settings settings;
+    private RealmConfig config;
+
+    private KerberosTicketValidator mockKerberosTicketValidator;
+    private Cache<String, User> mockUsernameUserCache;
+    private NativeRoleMappingStore mockNativeRoleMappingStore;
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private static final Set<String> roles;
+    static {
+        roles = new HashSet<>();
+        roles.add("admin");
+        roles.add("kibana_user");
+    }
+
+    @Before
+    public void setup() throws Exception {
+        threadPool = new TestThreadPool("kerb realm tests");
+        resourceWatcherService = new ResourceWatcherService(Settings.EMPTY, threadPool);
+        Path dir = createTempDir();
+        globalSettings = Settings.builder().put("path.home", dir).build();
+        settings = KerberosTestCase.buildKerberosRealmSettings(KerberosTestCase.writeKeyTab(dir, "key.keytab", "asa").toString());
+    }
+
+    @After
+    public void shutdown() throws InterruptedException {
+        resourceWatcherService.stop();
+        terminate(threadPool);
+    }
+
+    public void testSupportAuthentication() {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+
+        final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(randomByteArrayOfLength(5));
+        assertTrue(kerberosRealm.supports(kerberosAuthenticationToken));
+        final UsernamePasswordToken usernamePasswordToken =
+                new UsernamePasswordToken(randomAlphaOfLength(5), new SecureString(new char[] { 'a', 'b', 'c' }));
+        assertFalse(kerberosRealm.supports(usernamePasswordToken));
+    }
+
+    public void testAuthenticateWithNonKerberosAuthneticationToken() {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+
+        final UsernamePasswordToken usernamePasswordToken =
+                new UsernamePasswordToken(randomAlphaOfLength(5), new SecureString(new char[] { 'a', 'b', 'c' }));
+        PlainActionFuture<AuthenticationResult> result = new PlainActionFuture<>();
+        kerberosRealm.authenticate(usernamePasswordToken, result);
+        assertNotNull(result);
+        assertSame(AuthenticationResult.notHandled(), result.actionGet());
+    }
+
+    public void testAuthenticateWithValidTicketSucessAuthnWithUserDetails() throws LoginException, GSSException {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+
+        final User expectedUser = new User("test@REALM", roles.toArray(new String[roles.size()]), null, null, null, true);
+        final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
+        when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                .thenReturn(new Tuple<>("test@REALM", "out-token"));
+        final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);
+
+        // authenticate
+        PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+        final AuthenticationResult result = future.actionGet();
+        final User user1 = result.getUser();
+        assertSuccessAuthnResult(expectedUser, "out-token", result);
+
+        // authenticate with cache
+        future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+        final User user2 = result.getUser();
+        assertSuccessAuthnResult(expectedUser, "out-token", result);
+        assertThat(user1, sameInstance(user2));
+
+        Mockito.verify(mockKerberosTicketValidator, Mockito.times(2)).validateTicket(Mockito.eq("*"),
+                Mockito.eq(GSSName.NT_HOSTBASED_SERVICE), AdditionalMatchers.aryEq(decodedTicket), Mockito.eq(config));
+    }
+
+    public void testAuthenticateDifferentFailureScenarios() throws LoginException, GSSException {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+        final boolean validTicket = rarely();
+        final boolean throwExceptionForInvalidTicket = validTicket ? false : randomBoolean();
+        final boolean returnOutToken = randomBoolean();
+        final boolean throwLoginException = randomBoolean();
+        final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
+        if (validTicket) {
+            when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                    .thenReturn(new Tuple<>("test@REALM", "out-token"));
+        } else {
+            if (throwExceptionForInvalidTicket) {
+                if (throwLoginException) {
+                    when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                            .thenThrow(new LoginException("Login Exception"));
+                } else {
+                    when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                            .thenThrow(new GSSException(GSSException.FAILURE));
+                }
+            } else {
+                if (returnOutToken) {
+                    when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                            .thenReturn(new Tuple<>(null, "out-token"));
+                } else {
+                    when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                            .thenReturn(null);
+                }
+            }
+        }
+        final boolean nullKerberosAuthnToken = rarely();
+        final KerberosAuthenticationToken kerberosAuthenticationToken =
+                nullKerberosAuthnToken ? null : new KerberosAuthenticationToken(decodedTicket);
+
+        // Verify
+        final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+        AuthenticationResult result = future.actionGet();
+        assertNotNull(result);
+        if (nullKerberosAuthnToken) {
+            assertEquals(AuthenticationResult.Status.CONTINUE, result.getStatus());
+            verifyZeroInteractions(mockUsernameUserCache, mockKerberosTicketValidator);
+        } else {
+            if (validTicket) {
+                assertEquals(AuthenticationResult.Status.SUCCESS, result.getStatus());
+                final User expectedUser = new User("test@REALM", roles.toArray(new String[roles.size()]), null, null, null, true);
+                assertEquals(expectedUser, result.getUser());
+                assertNotNull(threadPool.getThreadContext().getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE));
+                assertEquals(KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER + "out-token",
+                        threadPool.getThreadContext().getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE));
+                Mockito.verify(mockUsernameUserCache).put(Mockito.eq("test@REALM"), Mockito.eq(expectedUser));
+            } else {
+                assertEquals(AuthenticationResult.Status.TERMINATE, result.getStatus());
+                if (throwExceptionForInvalidTicket == false) {
+                    if (returnOutToken) {
+                        Map<String, List<String>> responseHeaders = threadPool.getThreadContext().getResponseHeaders();
+                        assertNotNull(responseHeaders);
+                        assertEquals(KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER + "out-token",
+                                responseHeaders.get(KerberosAuthenticationToken.WWW_AUTHENTICATE).get(0));
+                        assertEquals("failed to authenticate user, gss netogiation not complete", result.getMessage());
+                    } else {
+                        assertEquals("failed to authenticate user, invalid kerberos ticket", result.getMessage());
+                    }
+                } else {
+                    if (throwLoginException) {
+                        assertEquals("failed to authenticate user, service login failure", result.getMessage());
+                    } else {
+                        assertEquals("failed to authenticate user, GSS negotiation failure", result.getMessage());
+                    }
+                    assertTrue(result.getException() instanceof ElasticsearchSecurityException);
+                    final List<String> wwwAuthnHeader = ((ElasticsearchSecurityException) result.getException())
+                            .getHeader(KerberosAuthenticationToken.WWW_AUTHENTICATE);
+                    assertNotNull(wwwAuthnHeader);
+                    assertEquals(KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER.trim(), wwwAuthnHeader.get(0));
+                }
+                verifyZeroInteractions(mockUsernameUserCache);
+            }
+            Mockito.verify(mockKerberosTicketValidator).validateTicket(Mockito.eq("*"), Mockito.eq(GSSName.NT_HOSTBASED_SERVICE),
+                    AdditionalMatchers.aryEq(decodedTicket), Mockito.eq(config));
+        }
+    }
+
+    public void testFailedAuthorization() throws LoginException, GSSException {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+        final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
+        when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                .thenReturn(new Tuple<>("does-not-exist@REALM", "out-token"));
+        final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);
+
+        final PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+
+        thrown.expect(ElasticsearchSecurityException.class);
+        thrown.expectMessage("Expected UPN 'test@REALM' but was 'does-not-exist@REALM");
+        future.actionGet();
+        verifyZeroInteractions(mockUsernameUserCache);
+    }
+
+    public void testLookupUser() {
+        final KerberosRealm kerberosRealm = createKerberosRealm("test@REALM");
+        final PlainActionFuture<User> future = new PlainActionFuture<>();
+        kerberosRealm.lookupUser("test@REALM", future);
+        assertNull(future.actionGet());
+    }
+
+    public void testCacheInvalidationScenarios() throws LoginException, GSSException {
+        createRealmConfig();
+        List<String> userNames = Arrays.asList(randomAlphaOfLength(5) + "@REALM", randomAlphaOfLength(5) + "@REALM");
+        final AtomicBoolean invalidateKerbRealmActionState = new AtomicBoolean(false);
+        final NativeRoleMappingStore roleMapper = roleMappingStore("test-kerb-realm", userNames, invalidateKerbRealmActionState);
+
+        final KerberosTicketValidator mockKerberosTicketValidator = mock(KerberosTicketValidator.class);
+        final KerberosRealm kerberosRealm = new KerberosRealm(config, roleMapper, mockKerberosTicketValidator, threadPool, null);
+        String authNUsername = randomFrom(userNames);
+        String outToken = randomAlphaOfLength(5);
+        final byte[] decodedTicket = "base64encodedticket".getBytes(StandardCharsets.UTF_8);
+        when(mockKerberosTicketValidator.validateTicket("*", GSSName.NT_HOSTBASED_SERVICE, decodedTicket, config))
+                .thenReturn(new Tuple<>(authNUsername, outToken));
+        final User expectedUser = new User(authNUsername, roles.toArray(new String[roles.size()]), null, null, null, true);
+
+        final KerberosAuthenticationToken kerberosAuthenticationToken = new KerberosAuthenticationToken(decodedTicket);
+        PlainActionFuture<AuthenticationResult> future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+        AuthenticationResult result = future.actionGet();
+        final User user1 = result.getUser();
+
+        assertSuccessAuthnResult(expectedUser, outToken, result);
+
+        String expireThisUser = randomFrom(userNames);
+        boolean expireAll = randomBoolean();
+        if (expireAll) {
+            // Must call realm.expireAll internally after state change
+            roleMapper.onSecurityIndexStateChange(dummyState(ClusterHealthStatus.RED), dummyState(ClusterHealthStatus.GREEN));
+            assertTrue(invalidateKerbRealmActionState.get());
+            kerberosRealm.expireAll();
+        } else {
+            kerberosRealm.expire(expireThisUser);
+        }
+
+        future = new PlainActionFuture<>();
+        kerberosRealm.authenticate(kerberosAuthenticationToken, future);
+        result = future.actionGet();
+        final User user2 = result.getUser();
+
+        assertSuccessAuthnResult(expectedUser, outToken, result);
+
+        if (expireAll || expireThisUser.equals(authNUsername)) {
+            assertFalse(user1 == user2);
+        } else {
+            assertThat(user1, sameInstance(user2));
+        }
+    }
+
+    private SecurityIndexManager.State dummyState(ClusterHealthStatus indexStatus) {
+        return new SecurityIndexManager.State(true, true, true, true, null, indexStatus);
+    }
+
+    private void assertSuccessAuthnResult(final User expectedUser, final String outToken, final AuthenticationResult result) {
+        assertNotNull(result);
+        assertEquals(AuthenticationResult.Status.SUCCESS, result.getStatus());
+        assertEquals(expectedUser, result.getUser());
+        Map<String, List<String>> responseHeaders = threadPool.getThreadContext().getResponseHeaders();
+        assertNotNull(responseHeaders);
+        assertEquals(KerberosAuthenticationToken.NEGOTIATE_AUTH_HEADER + outToken,
+                responseHeaders.get(KerberosAuthenticationToken.WWW_AUTHENTICATE).get(0));
+    }
+
+    @SuppressWarnings("unchecked")
+    private KerberosRealm createKerberosRealm(final String userForRoleMapping) {
+        createRealmConfig();
+        mockNativeRoleMappingStore = mockRoleMappingStore(userForRoleMapping);
+        mockUsernameUserCache = mock(Cache.class);
+        mockKerberosTicketValidator = mock(KerberosTicketValidator.class);
+        final KerberosRealm kerberosRealm =
+                new KerberosRealm(config, mockNativeRoleMappingStore, mockKerberosTicketValidator, threadPool, mockUsernameUserCache);
+        return kerberosRealm;
+    }
+
+    private void createRealmConfig() {
+        config = new RealmConfig("test-kerb-realm", settings, globalSettings, TestEnvironment.newEnvironment(globalSettings),
+                new ThreadContext(globalSettings));
+    }
+
+    private NativeRoleMappingStore mockRoleMappingStore(final String expectedUserName) {
+        return roleMappingStore(null, Arrays.asList(expectedUserName), null);
+    }
+
+    @SuppressWarnings("unchecked")
+    private NativeRoleMappingStore roleMappingStore(final String realmName, final List<String> expectedUserNames,
+            final AtomicBoolean expireAll) {
+        final Client mockClient = mock(Client.class);
+        when(mockClient.threadPool()).thenReturn(threadPool);
+        when(mockClient.settings()).thenReturn(settings);
+
+        doAnswer(invocationOnMock -> {
+            ActionListener<ClearRealmCacheResponse> listener = (ActionListener<ClearRealmCacheResponse>) invocationOnMock.getArguments()[2];
+            listener.onResponse(new ClearRealmCacheResponse(new ClusterName("cluster"), Collections.emptyList(), Collections.emptyList()));
+            return null;
+        }).when(mockClient).execute(eq(ClearRealmCacheAction.INSTANCE),
+                Mockito.argThat(new ClearRealmCacheRequestMatcher(realmName, expireAll)), any(ActionListener.class));
+
+        final NativeRoleMappingStore store = new NativeRoleMappingStore(Settings.EMPTY, mockClient, mock(SecurityIndexManager.class));
+        final NativeRoleMappingStore roleMapper = spy(store);
+
+        Mockito.doAnswer(invocation -> {
+            final UserRoleMapper.UserData userData = (UserRoleMapper.UserData) invocation.getArguments()[0];
+            final ActionListener<Set<String>> listener = (ActionListener<Set<String>>) invocation.getArguments()[1];
+            if (expectedUserNames.contains(userData.getUsername())) {
+                listener.onResponse(roles);
+            } else {
+                if (expectedUserNames.size() == 1) {
+                    listener.onFailure(Exceptions.authorizationError(
+                            "Expected UPN '" + expectedUserNames.get(0) + "' but was '" + userData.getUsername() + "'"));
+                } else {
+                    listener.onFailure(Exceptions
+                            .authorizationError("Expected UPN '" + expectedUserNames + "' but was '" + userData.getUsername() + "'"));
+                }
+            }
+            return null;
+        }).when(roleMapper).resolveRoles(any(UserRoleMapper.UserData.class), any(ActionListener.class));
+
+        return roleMapper;
+    }
+
+    class ClearRealmCacheRequestMatcher extends BaseMatcher<ClearRealmCacheRequest> {
+        final String expectedRealmNameInRequest;
+        final AtomicBoolean invalidateKerbRealmActionState;
+
+        ClearRealmCacheRequestMatcher(final String expectedRealmNameInRequest, final AtomicBoolean invalidateKerbRealmActionState) {
+            this.expectedRealmNameInRequest = expectedRealmNameInRequest;
+            this.invalidateKerbRealmActionState = invalidateKerbRealmActionState;
+        }
+
+        @Override
+        public boolean matches(Object item) {
+            if (item instanceof ClearRealmCacheRequest) {
+                if (Strings.isNullOrEmpty(expectedRealmNameInRequest)) {
+                    return true;
+                }
+                if (Arrays.stream(((ClearRealmCacheRequest) item).realms()).anyMatch((s) -> s.equals(expectedRealmNameInRequest))) {
+                    if (invalidateKerbRealmActionState.compareAndSet(false, true)) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+
+        @Override
+        public void describeTo(Description description) {
+        }
+    }
+}


### PR DESCRIPTION
This commit adds support for Kerberos Realm.
It caches User after successful authentication.
There can be only one Kerberos realm enforced via bootstrap check.

Depending on the AuthenticationResult it writes corresponding
response headers in thread context
success -> "WWW-Authenticate: Negotiate <Base64OutToken>"
terminate -> 401 Unauhorized "WWW-Authenticate: Negotiate "

For user details, it uses native role mapper store.
In future we will be integrating with AD/LDAP via lookup realm

During testing found that PkiRealm, KerberosRealm would not be
able to register for refreshRealmOnChange with UserRoleMapper.
This change also addresses by changing to use CachingRealm instead
of CachingUsernamePasswordRealm.

Handling 'WWW-Authenticate' response header:

This change handles setting of 'WWW-Authenticate' reponse header.
I think we will have opinions over here how to handle it and I am open
for ideas.

As per RFC https://tools.ietf.org/html/rfc7235#section-4.1,
we can have custom Realms defining their own response header value for
'WWW-Authenticate' header. So the value for response header value is
driven by realms.
Introduced a default getWWWAuthenticateHeaderValue in Realm which uses
'Basic' auth scheme by default. There are some auth scheme which do not
specify anything related to WWW-Authenticate header like SAML. But most
of the realms would define or use the existing schemes like 'Basic',
'Digest', 'Bearer', 'Negotiate' etc.
For example, unofficially 'SAML' has been used as auth scheme for SAML.
At the startup, Security#createComponents will take care of creating
DefaultAuthenticationFailureHandler with default response header for
'WWW-Authenticate' header based on the ordering.

Testing:
Unit tests and manual testing freeipa env and curl api invocations.

<!--
Thank you for your interest in and contributing to Elasticsearch! There
are a few simple things to check before submitting your pull request
that can help with the review process. You should delete these items
from your submission, but they are here to help bring them to your
attention.
-->

- Have you signed the [contributor license agreement](https://www.elastic.co/contributor-agreement)?
- Have you followed the [contributor guidelines](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md)?
- If submitting code, have you built your formula locally prior to submission with `gradle check`?
- If submitting code, is your pull request against master? Unless there is a good reason otherwise, we prefer pull requests against master and will backport as needed.
- If submitting code, have you checked that your submission is for an [OS that we support](https://www.elastic.co/support/matrix#show_os)?
- If you are submitting this code for a class then read our [policy](https://github.com/elastic/elasticsearch/blob/master/CONTRIBUTING.md#contributing-as-part-of-a-class) for that.
